### PR TITLE
fix npm publish action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,6 +35,7 @@ jobs:
   publish:
     needs: [dist]
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       id-token: write
       contents: read
@@ -52,7 +53,8 @@ jobs:
         with:
           name: dist
           path: dist/
-
+      - run: node --version
+      - run: npm --version
       - run: npm ci
 
       # Needed for npm trusted publishing support

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24.10.0
           registry-url: https://registry.npmjs.org/
 
       # Download the built artifacts
@@ -58,6 +58,6 @@ jobs:
       - run: npm ci
 
       # Needed for npm trusted publishing support
-      #- run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.2
 
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/checkout@v4
@@ -53,11 +54,9 @@ jobs:
         with:
           name: dist
           path: dist/
-      - run: node --version
-      - run: npm --version
       - run: npm ci
 
-      # Needed for npm trusted publishing support
+      # Needed for npm trusted publishing support, using latest gives error so pin a recent version
       - run: npm install -g npm@11.6.2
 
       - run: npm publish --access public --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,7 +38,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +56,6 @@ jobs:
       - run: npm ci
 
       # Needed for npm trusted publishing support
-      - run: npm install -g npm@latest
+      #- run: npm install -g npm@latest
 
       - run: npm publish --access public --provenance


### PR DESCRIPTION
The npm publish workflow has been fixed.

The npm version used needs to be pinned at a recent version so it can use "trusted publishing" aka OIDC when uploading to the npm registry.

Using 'latest' as the npm version had errors. Since actions are moving to use node 24 that may fix the issue if we start using that instead.